### PR TITLE
Pass correct pointer to cleanup in ensure_vector_match error path

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -1137,7 +1137,7 @@ int ensure_vector_match(sqlite3_value *aValue, sqlite3_value *bValue, void **a,
   if (rc != SQLITE_OK) {
     *outError = sqlite3_mprintf("Error reading 2nd vector: %s", error);
     sqlite3_free(error);
-    aCleanup(a);
+    aCleanup(*a);
     return SQLITE_ERROR;
   }
 


### PR DESCRIPTION
When the second vector fails to parse in ensure_vector_match(), the cleanup function for the first vector was called with 'a' (void**) instead of '*a' (void*). This caused sqlite3_free to be called with a stack address instead of the heap-allocated vector, resulting in a crash:

    malloc: Non-aligned pointer being freed
    Fatal error 6: Aborted

The fix dereferences the pointer correctly, matching how cleanup is done in other error paths.

This fix has a unit test that will crash without the patch.