### PR TITLE
MMR reranking via mmr_lambda hidden column

### DIFF
--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -3497,6 +3497,7 @@ static sqlite3_module vec_npy_eachModule = {
 #define VEC0_COLUMN_OFFSET_DISTANCE 1
 #define VEC0_COLUMN_OFFSET_K 2
 #define VEC0_COLUMN_OFFSET_TABLE_NAME 3
+#define VEC0_COLUMN_OFFSET_MMR_LAMBDA 4
 
 #define VEC0_SHADOW_INFO_NAME "\"%w\".\"%w_info\""
 
@@ -3775,6 +3776,14 @@ int vec0_column_k_idx(vec0_vtab *p) {
 int vec0_column_table_name_idx(vec0_vtab *p) {
   return VEC0_COLUMN_USERN_START + (vec0_num_defined_user_columns(p) - 1) +
          VEC0_COLUMN_OFFSET_TABLE_NAME;
+}
+
+/**
+ * Returns the column index for the hidden "mmr_lambda" column.
+ */
+int vec0_column_mmr_lambda_idx(vec0_vtab *p) {
+  return VEC0_COLUMN_USERN_START + (vec0_num_defined_user_columns(p) - 1) +
+         VEC0_COLUMN_OFFSET_MMR_LAMBDA;
 }
 
 /**
@@ -5039,7 +5048,7 @@ static int vec0_init(sqlite3 *db, void *pAux, int argc, const char *const *argv,
 
   }
   sqlite3_str_appendall(createStr, " distance hidden, k hidden, ");
-  sqlite3_str_appendf(createStr, "%s hidden) ", tableName);
+  sqlite3_str_appendf(createStr, "%s hidden, mmr_lambda hidden) ", tableName);
   if (pkColumnName) {
     sqlite3_str_appendall(createStr, "without rowid ");
   }
@@ -5454,6 +5463,7 @@ typedef enum  {
 
   // ~~~ ??? ~~~ //
   VEC0_IDXSTR_KIND_METADATA_CONSTRAINT = '&',
+  VEC0_IDXSTR_KIND_KNN_MMR_LAMBDA = '#',
 } vec0_idxstr_kind;
 
 // The different SQLITE_INDEX_CONSTRAINT values that vec0 partition key columns
@@ -5523,6 +5533,7 @@ static int vec0BestIndex(sqlite3_vtab *pVTab, sqlite3_index_info *pIdxInfo) {
   int iLimitTerm = -1;
   int iRowidTerm = -1;
   int iKTerm = -1;
+  int iMmrLambdaTerm = -1;
   int iRowidInTerm = -1;
   int hasAuxConstraint = 0;
 
@@ -5578,6 +5589,9 @@ static int vec0BestIndex(sqlite3_vtab *pVTab, sqlite3_index_info *pIdxInfo) {
     }
     if (op == SQLITE_INDEX_CONSTRAINT_EQ && iColumn == vec0_column_k_idx(p)) {
       iKTerm = i;
+    }
+    if (op == SQLITE_INDEX_CONSTRAINT_EQ && iColumn == vec0_column_mmr_lambda_idx(p)) {
+      iMmrLambdaTerm = i;
     }
     if(
       (op != SQLITE_INDEX_CONSTRAINT_LIMIT && op != SQLITE_INDEX_CONSTRAINT_OFFSET)
@@ -5909,7 +5923,12 @@ static int vec0BestIndex(sqlite3_vtab *pVTab, sqlite3_index_info *pIdxInfo) {
       sqlite3_str_appendchar(idxStr, 1, '_');
     }
 
-
+    if (iMmrLambdaTerm >= 0) {
+      pIdxInfo->aConstraintUsage[iMmrLambdaTerm].argvIndex = argvIndex++;
+      pIdxInfo->aConstraintUsage[iMmrLambdaTerm].omit = 1;
+      sqlite3_str_appendchar(idxStr, 1, VEC0_IDXSTR_KIND_KNN_MMR_LAMBDA);
+      sqlite3_str_appendchar(idxStr, 3, '_');
+    }
 
     pIdxInfo->idxNum = iMatchVectorTerm;
     pIdxInfo->estimatedCost = 30.0;
@@ -7440,6 +7459,159 @@ cleanup:
   return rc;
 }
 
+/**
+ * Compute pairwise distance between two vectors stored in the vec0 table's
+ * native format.  Handles float32, int8, and bit element types with the
+ * appropriate metric (L2, cosine, L1, hamming).
+ */
+static f32 vec0_compute_distance(struct VectorColumnDefinition *vector_column,
+                                 const void *a, const void *b) {
+  size_t dims = vector_column->dimensions;
+  switch (vector_column->element_type) {
+  case SQLITE_VEC_ELEMENT_TYPE_FLOAT32:
+    switch (vector_column->distance_metric) {
+    case VEC0_DISTANCE_METRIC_L2:
+      return distance_l2_sqr_float(a, b, &dims);
+    case VEC0_DISTANCE_METRIC_L1:
+      return (f32)distance_l1_f32(a, b, &dims);
+    case VEC0_DISTANCE_METRIC_COSINE:
+      return distance_cosine_float(a, b, &dims);
+    }
+    break;
+  case SQLITE_VEC_ELEMENT_TYPE_INT8:
+    switch (vector_column->distance_metric) {
+    case VEC0_DISTANCE_METRIC_L2:
+      return distance_l2_sqr_int8(a, b, &dims);
+    case VEC0_DISTANCE_METRIC_L1:
+      return (f32)distance_l1_int8(a, b, &dims);
+    case VEC0_DISTANCE_METRIC_COSINE:
+      return distance_cosine_int8(a, b, &dims);
+    }
+    break;
+  case SQLITE_VEC_ELEMENT_TYPE_BIT:
+    return distance_hamming(a, b, &dims);
+  }
+  return 0.0f;
+}
+
+/**
+ * MMR greedy reranking of KNN results.
+ *
+ * Loads vectors for top-k candidates, then iteratively selects the
+ * candidate with the best MMR score:
+ *   MMR(d) = lambda * relevance(d) - (1-lambda) * max_sim(d, S)
+ *
+ * where relevance = 1 - normalized_distance, and max_sim is the maximum
+ * cosine similarity between d and any already-selected result.
+ *
+ * Reorders topk_rowids and topk_distances in place.
+ * After return, the first k_target entries are the MMR-selected results.
+ */
+static int vec0_mmr_rerank(
+    vec0_vtab *p,
+    int vectorColumnIdx,
+    struct VectorColumnDefinition *vector_column,
+    i64 *topk_rowids,
+    f32 *topk_distances,
+    i64 k_used,
+    i64 k_target,
+    f32 mmr_lambda
+) {
+    int rc = SQLITE_OK;
+
+    // 1. Allocate vector storage for all candidates
+    void **vectors = sqlite3_malloc64(k_used * sizeof(void *));
+    if (!vectors) return SQLITE_NOMEM;
+    memset(vectors, 0, k_used * sizeof(void *));
+
+    f32 *relevance = NULL;
+    i64 *out_rowids = NULL;
+    f32 *out_distances = NULL;
+    void **out_vectors = NULL;
+    u8 *selected = NULL;
+
+    // 2. Load vectors from shadow tables
+    for (i64 i = 0; i < k_used; i++) {
+        rc = vec0_get_vector_data(p, topk_rowids[i], vectorColumnIdx,
+                                  &vectors[i], NULL);
+        if (rc != SQLITE_OK) goto cleanup;
+    }
+
+    // 3. Normalize distances to [0, 1] for relevance scoring
+    f32 max_dist = 0.0f;
+    for (i64 i = 0; i < k_used; i++) {
+        if (topk_distances[i] > max_dist) max_dist = topk_distances[i];
+    }
+    if (max_dist < 1e-9f) max_dist = 1.0f;
+
+    relevance = sqlite3_malloc64(k_used * sizeof(f32));
+    if (!relevance) { rc = SQLITE_NOMEM; goto cleanup; }
+    for (i64 i = 0; i < k_used; i++) {
+        relevance[i] = 1.0f - (topk_distances[i] / max_dist);
+    }
+
+    // 4. Greedy MMR selection
+    out_rowids = sqlite3_malloc64(k_target * sizeof(i64));
+    out_distances = sqlite3_malloc64(k_target * sizeof(f32));
+    out_vectors = sqlite3_malloc64(k_target * sizeof(void *));
+    selected = sqlite3_malloc64(k_used);
+    if (!out_rowids || !out_distances || !out_vectors || !selected) {
+        rc = SQLITE_NOMEM; goto cleanup;
+    }
+    memset(selected, 0, k_used);
+
+    for (i64 step = 0; step < k_target && step < k_used; step++) {
+        f32 best_mmr = -FLT_MAX;
+        i64 best_idx = -1;
+
+        for (i64 i = 0; i < k_used; i++) {
+            if (selected[i]) continue;
+
+            // max similarity to already-selected results
+            f32 max_sim = 0.0f;
+            for (i64 j = 0; j < step; j++) {
+                f32 d = vec0_compute_distance(vector_column,
+                                              vectors[i], out_vectors[j]);
+                f32 sim = 1.0f - d;
+                if (sim > max_sim) max_sim = sim;
+            }
+
+            f32 mmr_score = mmr_lambda * relevance[i]
+                          - (1.0f - mmr_lambda) * max_sim;
+            if (mmr_score > best_mmr) {
+                best_mmr = mmr_score;
+                best_idx = i;
+            }
+        }
+
+        if (best_idx < 0) break;
+        selected[best_idx] = 1;
+        out_rowids[step] = topk_rowids[best_idx];
+        out_distances[step] = topk_distances[best_idx];
+        out_vectors[step] = vectors[best_idx];
+    }
+
+    // 5. Copy results back to input arrays
+    for (i64 i = 0; i < k_target; i++) {
+        topk_rowids[i] = out_rowids[i];
+        topk_distances[i] = out_distances[i];
+    }
+
+cleanup:
+    if (vectors) {
+        for (i64 i = 0; i < k_used; i++) {
+            sqlite3_free(vectors[i]);
+        }
+        sqlite3_free(vectors);
+    }
+    sqlite3_free(relevance);
+    sqlite3_free(out_rowids);
+    sqlite3_free(out_distances);
+    sqlite3_free(out_vectors);
+    sqlite3_free(selected);
+    return rc;
+}
+
 int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
                    const char *idxStr, int argc, sqlite3_value **argv) {
   assert(argc == (int)((strlen(idxStr)-1) / 4));
@@ -7468,6 +7640,7 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
   int query_idx =-1;
   int k_idx = -1;
   int rowid_in_idx = -1;
+  int mmr_lambda_idx = -1;
   for(int i = 0; i < argc; i++) {
     if(idxStr[1 + (i*4)] == VEC0_IDXSTR_KIND_KNN_MATCH) {
       query_idx = i;
@@ -7477,6 +7650,9 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
     }
     if(idxStr[1 + (i*4)] == VEC0_IDXSTR_KIND_KNN_ROWID_IN) {
       rowid_in_idx = i;
+    }
+    if(idxStr[1 + (i*4)] == VEC0_IDXSTR_KIND_KNN_MMR_LAMBDA) {
+      mmr_lambda_idx = i;
     }
   }
   assert(query_idx >= 0);
@@ -7538,6 +7714,29 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
     pCur->query_plan = VEC0_QUERY_PLAN_KNN;
     rc = SQLITE_OK;
     goto cleanup;
+  }
+
+  // MMR: validate lambda and over-fetch candidates
+#define SQLITE_VEC_MMR_OVERFETCH_FACTOR 5
+  f32 mmr_lambda = -1.0f;
+  i64 k_original = k;
+  if (mmr_lambda_idx >= 0) {
+    mmr_lambda = (f32)sqlite3_value_double(argv[mmr_lambda_idx]);
+    if (mmr_lambda < 0.0f || mmr_lambda > 1.0f) {
+      vtab_set_error(
+          &p->base,
+          "mmr_lambda value in knn query must be between 0.0 and 1.0, "
+          "provided %f",
+          (double)mmr_lambda);
+      rc = SQLITE_ERROR;
+      goto cleanup;
+    }
+    if (mmr_lambda < 1.0f) {
+      i64 k_internal = k * SQLITE_VEC_MMR_OVERFETCH_FACTOR;
+      if (k_internal > SQLITE_VEC_VEC0_K_MAX) k_internal = SQLITE_VEC_VEC0_K_MAX;
+      if (k_internal < k) k_internal = k;  // overflow guard
+      k = k_internal;
+    }
   }
 
 // handle when a `rowid in (...)` operation was provided
@@ -7688,6 +7887,16 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
                                   &topk_distances, &k_used);
   if (rc != SQLITE_OK) {
     goto cleanup;
+  }
+
+  // MMR reranking: select diverse subset from over-fetched candidates
+  if (mmr_lambda >= 0.0f && mmr_lambda < 1.0f && k_used > k_original) {
+    rc = vec0_mmr_rerank(p, vectorColumnIdx, vector_column,
+                         topk_rowids, topk_distances, k_used, k_original,
+                         mmr_lambda);
+    if (rc != SQLITE_OK) goto cleanup;
+    k_used = k_original;
+    k = k_original;
   }
 
   knn_data->current_idx = 0;
@@ -8867,6 +9076,12 @@ int vec0Update_Insert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
   if (sqlite3_value_type(argv[2 + vec0_column_k_idx(p)]) != SQLITE_NULL) {
     // IMP: V11875_28713
     vtab_set_error(pVTab, "A value was provided for the hidden \"k\" column.");
+    rc = SQLITE_ERROR;
+    goto cleanup;
+  }
+  // Cannot insert a value in the hidden "mmr_lambda" column
+  if (sqlite3_value_type(argv[2 + vec0_column_mmr_lambda_idx(p)]) != SQLITE_NULL) {
+    vtab_set_error(pVTab, "A value was provided for the hidden \"mmr_lambda\" column.");
     rc = SQLITE_ERROR;
     goto cleanup;
   }

--- a/sqlite-vec.c
+++ b/sqlite-vec.c
@@ -7505,7 +7505,9 @@ static f32 vec0_compute_distance(struct VectorColumnDefinition *vector_column,
  * cosine similarity between d and any already-selected result.
  *
  * Reorders topk_rowids and topk_distances in place.
- * After return, the first k_target entries are the MMR-selected results.
+ * After return, the first *out_n_selected entries are the MMR-selected results.
+ * out_n_selected may be less than k_target if the greedy selection exhausts
+ * candidates early.
  */
 static int vec0_mmr_rerank(
     vec0_vtab *p,
@@ -7515,7 +7517,8 @@ static int vec0_mmr_rerank(
     f32 *topk_distances,
     i64 k_used,
     i64 k_target,
-    f32 mmr_lambda
+    f32 mmr_lambda,
+    i64 *out_n_selected
 ) {
     int rc = SQLITE_OK;
 
@@ -7560,6 +7563,7 @@ static int vec0_mmr_rerank(
     }
     memset(selected, 0, k_used);
 
+    i64 n_selected = 0;
     for (i64 step = 0; step < k_target && step < k_used; step++) {
         f32 best_mmr = -FLT_MAX;
         i64 best_idx = -1;
@@ -7589,13 +7593,15 @@ static int vec0_mmr_rerank(
         out_rowids[step] = topk_rowids[best_idx];
         out_distances[step] = topk_distances[best_idx];
         out_vectors[step] = vectors[best_idx];
+        n_selected++;
     }
 
-    // 5. Copy results back to input arrays
-    for (i64 i = 0; i < k_target; i++) {
+    // 5. Copy only the actually-selected entries back to input arrays
+    for (i64 i = 0; i < n_selected; i++) {
         topk_rowids[i] = out_rowids[i];
         topk_distances[i] = out_distances[i];
     }
+    *out_n_selected = n_selected;
 
 cleanup:
     if (vectors) {
@@ -7891,11 +7897,12 @@ int vec0Filter_knn(vec0_cursor *pCur, vec0_vtab *p, int idxNum,
 
   // MMR reranking: select diverse subset from over-fetched candidates
   if (mmr_lambda >= 0.0f && mmr_lambda < 1.0f && k_used > k_original) {
+    i64 n_selected = 0;
     rc = vec0_mmr_rerank(p, vectorColumnIdx, vector_column,
                          topk_rowids, topk_distances, k_used, k_original,
-                         mmr_lambda);
+                         mmr_lambda, &n_selected);
     if (rc != SQLITE_OK) goto cleanup;
-    k_used = k_original;
+    k_used = n_selected;
     k = k_original;
   }
 

--- a/tests/__snapshots__/test-general.ambr
+++ b/tests/__snapshots__/test-general.ambr
@@ -108,7 +108,7 @@
 # ---
 # name: test_shadow.1
   OrderedDict({
-    'sql': "select * from pragma_table_list where type = 'shadow'",
+    'sql': "select * from pragma_table_list where type = 'shadow' order by name",
     'rows': list([
       OrderedDict({
         'schema': 'main',
@@ -136,14 +136,6 @@
       }),
       OrderedDict({
         'schema': 'main',
-        'name': 'v_rowids',
-        'type': 'shadow',
-        'ncol': 4,
-        'wr': 0,
-        'strict': 0,
-      }),
-      OrderedDict({
-        'schema': 'main',
         'name': 'v_metadatachunks00',
         'type': 'shadow',
         'ncol': 2,
@@ -158,12 +150,20 @@
         'wr': 0,
         'strict': 0,
       }),
+      OrderedDict({
+        'schema': 'main',
+        'name': 'v_rowids',
+        'type': 'shadow',
+        'ncol': 4,
+        'wr': 0,
+        'strict': 0,
+      }),
     ]),
   })
 # ---
 # name: test_shadow.2
   OrderedDict({
-    'sql': "select * from pragma_table_list where type = 'shadow'",
+    'sql': "select * from pragma_table_list where type = 'shadow' order by name",
     'rows': list([
     ]),
   })

--- a/tests/__snapshots__/test-knn-mmr.ambr
+++ b/tests/__snapshots__/test-knn-mmr.ambr
@@ -1,0 +1,243 @@
+# serializer version: 1
+# name: test_mmr_clustering
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 3,
+        'distance': 0.011511977761983871,
+      }),
+      OrderedDict({
+        'rowid': 4,
+        'distance': 0.020601648837327957,
+      }),
+      OrderedDict({
+        'rowid': 5,
+        'distance': 0.03227578103542328,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_clustering.1
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 8,
+        'distance': 1.0,
+      }),
+      OrderedDict({
+        'rowid': 3,
+        'distance': 0.011511977761983871,
+      }),
+      OrderedDict({
+        'rowid': 4,
+        'distance': 0.020601648837327957,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_cosine_diversity
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 3,
+        'distance': 0.02019595541059971,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_cosine_diversity.1
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 3,
+        'distance': 0.02019595541059971,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_cosine_diversity.2
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 5,
+        'distance': 1.0,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_cosine_diversity.3
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 5,
+        'distance': 1.0,
+      }),
+      OrderedDict({
+        'rowid': 4,
+        'distance': 1.0,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_edge_cases
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_edge_cases.1
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+    ]),
+  })
+# ---
+# name: test_mmr_error_invalid_lambda
+  dict({
+    'error': 'OperationalError',
+    'message': 'mmr_lambda value in knn query must be between 0.0 and 1.0, provided 1.500000',
+  })
+# ---
+# name: test_mmr_error_invalid_lambda.1
+  dict({
+    'error': 'OperationalError',
+    'message': 'mmr_lambda value in knn query must be between 0.0 and 1.0, provided -0.100000',
+  })
+# ---
+# name: test_mmr_insert_guard
+  dict({
+    'error': 'OperationalError',
+    'message': 'A value was provided for the hidden "mmr_lambda" column.',
+  })
+# ---
+# name: test_mmr_int8_vectors
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match vec_int8(?) and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 5.101129863760434e-05,
+      }),
+      OrderedDict({
+        'rowid': 5,
+        'distance': 1.0,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_l2_metric
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 3,
+        'distance': 0.028284257277846336,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.014142128638923168,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_with_distance_constraint
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ? and distance > 0.001',
+    'rows': list([
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 5,
+        'distance': 1.0,
+      }),
+      OrderedDict({
+        'rowid': 3,
+        'distance': 0.02019595541059971,
+      }),
+    ]),
+  })
+# ---
+# name: test_mmr_with_partition_key
+  OrderedDict({
+    'sql': 'select rowid, distance from v where embedding match ? and k = ? and category = ? and mmr_lambda = ?',
+    'rows': list([
+      OrderedDict({
+        'rowid': 1,
+        'distance': 0.0,
+      }),
+      OrderedDict({
+        'rowid': 2,
+        'distance': 0.005062814336270094,
+      }),
+      OrderedDict({
+        'rowid': 5,
+        'distance': 1.0,
+      }),
+    ]),
+  })
+# ---

--- a/tests/test-general.py
+++ b/tests/test-general.py
@@ -13,12 +13,12 @@ def test_shadow(db, snapshot):
     )
     assert exec(db, "select * from sqlite_master order by name") == snapshot()
     assert (
-        exec(db, "select * from pragma_table_list where type = 'shadow'") == snapshot()
+        exec(db, "select * from pragma_table_list where type = 'shadow' order by name") == snapshot()
     )
 
     db.execute("drop table v;")
     assert (
-        exec(db, "select * from pragma_table_list where type = 'shadow'") == snapshot()
+        exec(db, "select * from pragma_table_list where type = 'shadow' order by name") == snapshot()
     )
 
 

--- a/tests/test-knn-mmr.py
+++ b/tests/test-knn-mmr.py
@@ -1,0 +1,249 @@
+import sqlite3
+from collections import OrderedDict
+
+
+def test_mmr_cosine_diversity(db, snapshot):
+    """MMR should select diverse results from clustered candidates."""
+    db.execute(
+        "create virtual table v using vec0(embedding float[3] distance_metric=cosine)"
+    )
+    db.executemany(
+        "insert into v(rowid, embedding) values (?, ?)",
+        [
+            [1, "[1,0,0]"],
+            [2, "[0.99,0.1,0]"],
+            [3, "[0.98,0.2,0]"],
+            [4, "[0,1,0]"],
+            [5, "[0,0,1]"],
+        ],
+    )
+
+    BASE_KNN = "select rowid, distance from v where embedding match ? and k = ?"
+
+    # Baseline: no MMR — returns nearest neighbors
+    assert exec(db, BASE_KNN, ["[1,0,0]", 3]) == snapshot()
+
+    # lambda=1.0 — pure relevance, same order as baseline
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 3, 1.0]) == snapshot()
+    )
+
+    # lambda=0.5 — balanced: should include diverse results
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 3, 0.5]) == snapshot()
+    )
+
+    # lambda=0.0 — pure diversity
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 3, 0.0]) == snapshot()
+    )
+
+
+def test_mmr_l2_metric(db, snapshot):
+    """MMR should work with default L2 distance metric."""
+    db.execute("create virtual table v using vec0(embedding float[3])")
+    db.executemany(
+        "insert into v(rowid, embedding) values (?, ?)",
+        [
+            [1, "[1,0,0]"],
+            [2, "[0.99,0.01,0]"],
+            [3, "[0.98,0.02,0]"],
+            [4, "[0,1,0]"],
+            [5, "[0,0,1]"],
+        ],
+    )
+
+    BASE_KNN = "select rowid, distance from v where embedding match ? and k = ?"
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 3, 0.5]) == snapshot()
+    )
+
+
+def test_mmr_int8_vectors(db, snapshot):
+    """MMR should work with int8 vector element type."""
+    db.execute(
+        "create virtual table v using vec0(embedding int8[3] distance_metric=cosine)"
+    )
+    for rowid, vec in [
+        (1, "[100,0,0]"),
+        (2, "[99,1,0]"),
+        (3, "[98,2,0]"),
+        (4, "[0,100,0]"),
+        (5, "[0,0,100]"),
+    ]:
+        db.execute(
+            "insert into v(rowid, embedding) values (?, vec_int8(?))", [rowid, vec]
+        )
+
+    assert (
+        exec(
+            db,
+            "select rowid, distance from v where embedding match vec_int8(?) and k = ? and mmr_lambda = ?",
+            ["[100,0,0]", 3, 0.5],
+        )
+        == snapshot()
+    )
+
+
+def test_mmr_clustering(db, snapshot):
+    """MMR should break cluster monopoly in results."""
+    db.execute(
+        "create virtual table v using vec0(embedding float[3] distance_metric=cosine)"
+    )
+    db.executemany(
+        "insert into v(rowid, embedding) values (?, ?)",
+        [
+            # cluster 1: near [1,0,0]
+            [1, "[1.0,0,0]"],
+            [2, "[0.99,0.1,0]"],
+            [3, "[0.98,0.15,0]"],
+            [4, "[0.97,0.2,0]"],
+            [5, "[0.96,0.25,0]"],
+            # cluster 2: near [0,1,0]
+            [6, "[0,1.0,0]"],
+            [7, "[0.1,0.99,0]"],
+            # cluster 3: near [0,0,1]
+            [8, "[0,0,1.0]"],
+            [9, "[0,0.1,0.99]"],
+        ],
+    )
+
+    BASE_KNN = "select rowid, distance from v where embedding match ? and k = ?"
+
+    # Without MMR: top 5 all from cluster 1
+    assert exec(db, BASE_KNN, ["[1,0,0]", 5]) == snapshot()
+
+    # With MMR: should include results from other clusters
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 5, 0.5]) == snapshot()
+    )
+
+
+def test_mmr_with_distance_constraint(db, snapshot):
+    """MMR should compose with distance column constraints."""
+    db.execute(
+        "create virtual table v using vec0(embedding float[3] distance_metric=cosine)"
+    )
+    db.executemany(
+        "insert into v(rowid, embedding) values (?, ?)",
+        [
+            [1, "[1,0,0]"],
+            [2, "[0.99,0.1,0]"],
+            [3, "[0.98,0.2,0]"],
+            [4, "[0,1,0]"],
+            [5, "[0,0,1]"],
+        ],
+    )
+
+    # distance > 0.001 excludes the exact match, MMR diversifies the rest
+    assert (
+        exec(
+            db,
+            "select rowid, distance from v where embedding match ? and k = ? and mmr_lambda = ? and distance > 0.001",
+            ["[1,0,0]", 3, 0.5],
+        )
+        == snapshot()
+    )
+
+
+def test_mmr_with_partition_key(db, snapshot):
+    """MMR should compose with partition key constraints."""
+    db.execute(
+        "create virtual table v using vec0(category text partition key, embedding float[3] distance_metric=cosine)"
+    )
+    db.executemany(
+        "insert into v(rowid, category, embedding) values (?, ?, ?)",
+        [
+            [1, "a", "[1,0,0]"],
+            [2, "a", "[0.99,0.1,0]"],
+            [3, "a", "[0.98,0.2,0]"],
+            [4, "a", "[0,1,0]"],
+            [5, "a", "[0,0,1]"],
+            [6, "b", "[1,0,0]"],
+        ],
+    )
+
+    BASE_KNN = "select rowid, distance from v where embedding match ? and k = ? and category = ?"
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 3, "a", 0.5])
+        == snapshot()
+    )
+
+
+def test_mmr_edge_cases(db, snapshot):
+    """Edge cases: k=1, k=0, single row, lambda boundaries."""
+    db.execute(
+        "create virtual table v using vec0(embedding float[3] distance_metric=cosine)"
+    )
+    db.executemany(
+        "insert into v(rowid, embedding) values (?, ?)",
+        [
+            [1, "[1,0,0]"],
+            [2, "[0,1,0]"],
+        ],
+    )
+
+    BASE_KNN = "select rowid, distance from v where embedding match ? and k = ?"
+
+    # k=1 with MMR — should return closest
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 1, 0.5]) == snapshot()
+    )
+
+    # k=0 with MMR — should return empty
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 0, 0.5]) == snapshot()
+    )
+
+
+def test_mmr_error_invalid_lambda(db, snapshot):
+    """Out-of-range mmr_lambda should return an error."""
+    db.execute(
+        "create virtual table v using vec0(embedding float[3] distance_metric=cosine)"
+    )
+    db.execute("insert into v(rowid, embedding) values (1, '[1,0,0]')")
+
+    BASE_KNN = "select rowid, distance from v where embedding match ? and k = ?"
+
+    # lambda > 1.0
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 1, 1.5]) == snapshot()
+    )
+
+    # lambda < 0.0
+    assert (
+        exec(db, BASE_KNN + " and mmr_lambda = ?", ["[1,0,0]", 1, -0.1]) == snapshot()
+    )
+
+
+def test_mmr_insert_guard(db, snapshot):
+    """Cannot insert a value for the hidden mmr_lambda column."""
+    db.execute("create virtual table v using vec0(embedding float[3])")
+
+    assert (
+        exec(
+            db,
+            "insert into v(rowid, embedding, mmr_lambda) values (1, '[1,0,0]', 0.5)",
+        )
+        == snapshot()
+    )
+
+
+def exec(db, sql, parameters=[]):
+    try:
+        rows = db.execute(sql, parameters).fetchall()
+    except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
+        return {
+            "error": e.__class__.__name__,
+            "message": str(e),
+        }
+    a = []
+    for row in rows:
+        o = OrderedDict()
+        for k in row.keys():
+            o[k] = row[k]
+        a.append(o)
+    result = OrderedDict()
+    result["sql"] = sql
+    result["rows"] = a
+    return result


### PR DESCRIPTION
Rebased version of asg017/sqlite-vec#267 (issue: asg017/sqlite-vec#266) for this fork. Adds a `mmr_lambda` hidden column to vec0 for [Maximal Marginal Relevance](https://www.cs.cmu.edu/~jgc/publication/The_Use_MMR_Diversity_Based_LTMIR_1998.pdf) reranking in KNN queries.

```sql
SELECT rowid, distance FROM vec_items
WHERE embedding MATCH ? AND k = 10 AND mmr_lambda = 0.5;
```

Composes with this fork's distance constraints, partition keys, and all vector types/metrics.

Also fixes the pre-existing test_shadow snapshot failure (missing ORDER BY on pragma_table_list).

Full design and rationale in the upstream PR.

